### PR TITLE
fix url escape in repo path part

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT=$(shell basename "$(PWD)")
-APPVERS=0.1.2
+APPVERS=0.1.3
 GOFLAGS=-ldflags="-w -s" -trimpath -ldflags "-X main.version=${APPVERS}"
 GO111MODULE=on
 

--- a/tfsgit.go
+++ b/tfsgit.go
@@ -73,7 +73,7 @@ func tfsrequest(url string) *http.Response {
 
 func tfswalk(tfspath string) { // scan tfspath
 
-	url := cfg.Repo + "/items?scopePath=" + tfspath +
+	url := cfg.Repo + "/items?scopePath=" + url.QueryEscape(tfspath) +
 		"/&recursionLevel=OneLevel&versionDescriptor.versionType=branch&version=" + url.QueryEscape(cfg.Branch)
 	if cfg.Verbosity > 0 {
 		fmt.Printf("\nUrl %+v\n", url)


### PR DESCRIPTION
The old code was receiving the source from a path with a space incorrectly.